### PR TITLE
Bump all versions to most current

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -7,18 +7,20 @@ default_envs = nodemcuv2
 framework     = arduino
 monitor_speed = 115200
 upload_speed = 460800
+; build_type = debug
 lib_ignore = 
     ArduinoBearSSL
     Time
 
 lib_deps =
-    cotestatnt/AsyncTelegram @ ^1.1.2
-    ArduinoJson @ ^6.17.3
-    ESP Async WebServer@1.2.3
-    AsyncMqttClient@0.8.2
-    NTPClient@3.1.0
-    ESP Mail Client@^1.0.13
-    lorol/LittleFS_esp32 @ ^1.0.5
+    cotestatnt/AsyncTelegram      @ ^1.1.2   #2021
+    bblanchon/ArduinoJson         @ ^6.18.0     #2021
+    me-no-dev/ESP Async WebServer @ 1.2.3 #2019
+    ; lorol/ESPAsyncWebServer # as alternative
+    marvinroger/AsyncMqttClient   @ 0.8.2   #2017.01
+    arduino-libraries/NTPClient   @ 3.1.0   #2019.09 
+    mobizt/ESP Mail Client        @ ^1.2.0       #2021
+    lorol/LittleFS_esp32          @ ^1.0.6       #2021
 
 build_unflags =    
     -Wdeprecated-declarations
@@ -28,7 +30,7 @@ board_build.filesystem = littlefs
 extra_scripts = tools/replace_fs.py
 
 [env:nodemcuv2]
-platform = espressif8266
+platform = espressif8266 @ 3.0.0
 board = nodemcuv2
 build_flags =
     -Teagle.flash.4m.ld


### PR DESCRIPTION
Upgraded versions of espressif to 3.0.0 and other major dependencies.